### PR TITLE
Add export preview and tick density option

### DIFF
--- a/config/defaultv3settings.json
+++ b/config/defaultv3settings.json
@@ -191,6 +191,7 @@
         "backgroundColour"  : "#FFFFFF",
         "baseThickness"     : 1.0,
         "stripPadding"      : 5,
+        "tickDensity"       : 1.0,
         "dpi"               : 300,
         "scalingMode"       : "Percentage",
         "scalingPercentage" : 80,

--- a/src/python/ccpn/ui/gui/lib/OpenGL/CcpnOpenGL.py
+++ b/src/python/ccpn/ui/gui/lib/OpenGL/CcpnOpenGL.py
@@ -468,6 +468,8 @@ class CcpnGLWidget(QOpenGLWidget):
         self._multipletSymbolsEnabled = True
         self._multipletLabelsEnabled = True
         self._multipletArrowsEnabled = True
+        # density multiplier for axis tick marks
+        self._tickDensity = 1.0
         self._arrowType = 0
         self._arrowSize = 0
         self._arrowMinimum = 0
@@ -4245,6 +4247,18 @@ class CcpnGLWidget(QOpenGLWidget):
         self._rescaleAllAxes()
 
     @property
+    def tickDensity(self) -> float:
+        """Density multiplier for axis tick marks"""
+        return self._tickDensity
+
+    @tickDensity.setter
+    def tickDensity(self, value: float):
+        try:
+            self._tickDensity = max(0.1, float(value))
+        except Exception:
+            self._tickDensity = 1.0
+
+    @property
     def orderedAxes(self):
         return self._orderedAxes
 
@@ -5225,7 +5239,7 @@ class CcpnGLWidget(QOpenGLWidget):
                         # skip if one of the axes is zero
                         continue
 
-                    nlTarget = 10.**i  # i: 0 -> major tick-marks, 1 -> minor, (2 -> tiny-minor :) if needed)
+                    nlTarget = self.tickDensity * (10.**i)  # density adjusted
                     _pow = np.log10(abs(dist / nlTarget)) + 0.5
                     d = 10.**np.floor(_pow)
                     if 0 in d:

--- a/src/python/ccpn/ui/gui/lib/OpenGL/CcpnOpenGLDefs.py
+++ b/src/python/ccpn/ui/gui/lib/OpenGL/CcpnOpenGLDefs.py
@@ -178,6 +178,8 @@ GLSCALINGBYUNITS = 'Scaling By Units'
 GLSCALINGAXIS = 'Scaling Axis'
 GLPRINTFONT = 'Print Font'
 GLUSEPRINTFONT = 'Use Print Font'
+# axis tick density
+GLTICKDENSITY = 'Tick Density'
 # NOTE:ED - add tick marks?
 
 AXISDRAWOFFSET = 0.001

--- a/src/python/ccpn/ui/gui/lib/OpenGL/CcpnOpenGLExport.py
+++ b/src/python/ccpn/ui/gui/lib/OpenGL/CcpnOpenGLExport.py
@@ -75,7 +75,7 @@ from ccpn.ui.gui.lib.OpenGL.CcpnOpenGLDefs import (GLGRIDLINES, GLAXISLABELS, GL
                                                    GLSPECTRUMDISPLAY, GLBACKGROUND, GLBASETHICKNESS, GLSYMBOLTHICKNESS,
                                                    GLCONTOURTHICKNESS, GLFOREGROUND, GLSHOWSPECTRAONPHASE,
                                                    GLAXISTITLES, GLAXISUNITS, GLSTRIPDIRECTION, GLSTRIPPADDING,
-                                                   GLEXPORTDPI, GLCURSORS, GLDIAGONALLINE, GLDIAGONALSIDEBANDS,
+                                                   GLTICKDENSITY, GLEXPORTDPI, GLCURSORS, GLDIAGONALLINE, GLDIAGONALSIDEBANDS,
                                                    MAINVIEW, MAINVIEWFULLHEIGHT, MAINVIEWFULLWIDTH, RIGHTAXIS,
                                                    RIGHTAXISBAR, FULLRIGHTAXIS, FULLRIGHTAXISBAR, BOTTOMAXIS,
                                                    BOTTOMAXISBAR, FULLBOTTOMAXIS, FULLBOTTOMAXISBAR, FULLVIEW,
@@ -733,6 +733,9 @@ class GLExporter():
         self._oldValues = (self.strip._CcpnGLWidget.axisL, self.strip._CcpnGLWidget.axisR,
                            self.strip._CcpnGLWidget.axisT, self.strip._CcpnGLWidget.axisB)
         self._oldSize = (self.strip._CcpnGLWidget.w, self.strip._CcpnGLWidget.h)
+        # update tick density for export
+        self._oldTickDensity = getattr(self.strip._CcpnGLWidget, 'tickDensity', 1.0)
+        self.strip._CcpnGLWidget.tickDensity = self.params.get(GLTICKDENSITY, 1.0)
         try:
             self._updateAxes = False
             _dd = self.params[GLSTRIPREGIONS][self.strip.id]
@@ -886,10 +889,12 @@ class GLExporter():
                 # reset the strip to the original values
                 self.strip._CcpnGLWidget.axisL, self.strip._CcpnGLWidget.axisR, self.strip._CcpnGLWidget.axisT, self.strip._CcpnGLWidget.axisB = self._oldValues
                 self.strip._CcpnGLWidget.w, self.strip._CcpnGLWidget.h = self._oldSize
+            # reset tick density
+            self.strip._CcpnGLWidget.tickDensity = self._oldTickDensity
 
-                self.strip._CcpnGLWidget._rescaleAllZoom()
-                self.strip._CcpnGLWidget._buildGL()
-                self.strip._CcpnGLWidget.buildAxisLabels()
+            self.strip._CcpnGLWidget._rescaleAllZoom()
+            self.strip._CcpnGLWidget._buildGL()
+            self.strip._CcpnGLWidget.buildAxisLabels()
         except Exception:
             getLogger().debug('There was an issue resetting the strip')
 
@@ -900,6 +905,7 @@ class GLExporter():
                     # reset the strip to the original values
                     sdr = self.strip.spectrumDisplay._rightGLAxis
                     sdr.axisL, sdr.axisR, sdr.axisT, sdr.axisB = self._oldValues
+                    sdr.tickDensity = self._oldTickDensity
                     sdr._rescaleAllZoom()
                     sdr._buildGL()
                     sdr.buildAxisLabels(refresh=True)
@@ -907,6 +913,7 @@ class GLExporter():
                 # reset the strip to the original values
                 sdb = self.strip.spectrumDisplay._bottomGLAxis
                 sdb.axisL, sdb.axisR, sdb.axisT, sdb.axisB = self._oldValues
+                sdb.tickDensity = self._oldTickDensity
                 sdb._rescaleAllZoom()
                 sdb._buildGL()
                 sdb.buildAxisLabels(refresh=True)

--- a/src/python/ccpn/ui/gui/popups/ExportStripToFile.py
+++ b/src/python/ccpn/ui/gui/popups/ExportStripToFile.py
@@ -33,6 +33,8 @@ from PyQt5 import QtWidgets, QtCore, QtGui
 from dataclasses import dataclass
 from functools import partial
 from typing import Optional
+import tempfile
+from pathlib import Path
 
 from ccpn.core.lib.ContextManagers import catchExceptions, queueStateChange
 from ccpn.core.lib.WeakRefLib import WeakRefDescriptor
@@ -74,7 +76,8 @@ from ccpn.ui.gui.lib.OpenGL.CcpnOpenGLDefs import (GLFILENAME, GLGRIDLINES,
                                                    GLPRINTFONT, GLUSEPRINTFONT, GLSCALINGAXIS,
                                                    GLPEAKSYMBOLSENABLED, GLPEAKLABELSENABLED, GLPEAKARROWSENABLED,
                                                    GLMULTIPLETSYMBOLSENABLED,
-                                                   GLMULTIPLETLABELSENABLED, GLMULTIPLETARROWSENABLED)
+                                                   GLMULTIPLETLABELSENABLED, GLMULTIPLETARROWSENABLED,
+                                                   GLTICKDENSITY)
 from ccpn.ui.gui.lib.ChangeStateHandler import changeState
 from ccpn.util.Colour import (spectrumColours, addNewColour, fillColourPulldown, addNewColourString, hexToRgbRatio,
                               colourNameNoSpace)
@@ -462,6 +465,13 @@ class ExportStripToFilePopup(ExportDialogABC):
                                                             )
 
         row += 1
+        self.tickDensityBox = DoubleSpinBoxCompoundWidget(sFrame, grid=(row, 0), gridSpan=(1, 3), hAlign='left',
+                                                          labelText='Tick Density',
+                                                          decimals=2, step=0.1, minimum=0.1, maximum=5.0,
+                                                          callback=self._queueTickDensityCallback,
+                                                          )
+
+        row += 1
         self.stripPaddingBox = DoubleSpinBoxCompoundWidget(sFrame, grid=(row, 0), gridSpan=(1, 3), hAlign='left',
                                                            labelText='Strip Padding',
                                                            # value=5,
@@ -493,6 +503,11 @@ class ExportStripToFilePopup(ExportDialogABC):
 
         # widgets for handling fonts
         self._setupFontWidget(row, sFrame)
+        row += 1
+
+        self.previewLabel = Label(sFrame, grid=(row, 0), gridSpan=(1, 4), hAlign='centre')
+        self.previewLabel.setMinimumHeight(150)
+
         row += 1
 
         self.treeView = PrintTreeCheckBoxes(sFrame, project=None, grid=(row, 0), gridSpan=(1, 4))
@@ -1111,6 +1126,7 @@ class ExportStripToFilePopup(ExportDialogABC):
         self.backgroundColourBox.setCurrentText(spectrumColours[self.backgroundColour])
 
         self.baseThicknessBox.setValue(self.printSettings.baseThickness)
+        self.tickDensityBox.setValue(getattr(self.printSettings, 'tickDensity', 1.0))
         self.stripPaddingBox.setValue(self.printSettings.stripPadding)
         self.exportDpiBox.setValue(self.printSettings.dpi)
 
@@ -1625,6 +1641,7 @@ class ExportStripToFilePopup(ExportDialogABC):
                       GLFOREGROUND             : hexToRgbRatio(self.foregroundColour),
                       GLBACKGROUND             : hexToRgbRatio(self.backgroundColour),
                       GLBASETHICKNESS          : self.baseThicknessBox.getValue(),
+                      GLTICKDENSITY            : self.tickDensityBox.getValue(),
                       # unique per spectrumDisplay - may differ from preferences
                       GLSYMBOLTHICKNESS        : strip.symbolThickness,
                       GLCONTOURTHICKNESS       : strip.contourThickness,
@@ -1708,6 +1725,7 @@ class ExportStripToFilePopup(ExportDialogABC):
             # stop the popup from firing events
             super()._postInit()
         self._revertButton = self.getButton(self.RESETBUTTON)
+        self._schedulePreview()
 
     def _closeDialog(self):
         self._applyChanges()
@@ -1959,16 +1977,58 @@ class ExportStripToFilePopup(ExportDialogABC):
         textFromValue = self.baseThicknessBox.textFromValue
         oldValue = textFromValue(self.printSettings.baseThickness or 0.0)
         if _value >= 0 and textFromValue(_value) != oldValue:
+            self._schedulePreview()
             return partial(self._setBaseThickness, _value)
 
     def _setBaseThickness(self, value):
         self.printSettings.baseThickness = float(value)
 
     @queueStateChange(_verifyPopupApply)
+    def _queueTickDensityCallback(self, _value):
+        textFromValue = self.tickDensityBox.textFromValue
+        oldValue = textFromValue(getattr(self.printSettings, 'tickDensity', 1.0))
+        if _value >= 0 and textFromValue(_value) != oldValue:
+            self._schedulePreview()
+            return partial(self._setTickDensity, _value)
+
+    def _setTickDensity(self, value):
+        self.printSettings.tickDensity = float(value)
+
+    def _schedulePreview(self):
+        if not hasattr(self, '_previewTimer'):
+            self._previewTimer = QtCore.QTimer()
+            self._previewTimer.setSingleShot(True)
+            self._previewTimer.timeout.connect(self._generatePreview)
+        self._previewTimer.start(500)
+
+    def _generatePreview(self):
+        try:
+            params = self.buildParameters()
+            if not params:
+                return
+            if not (glWidgetRef := params.get(GLWIDGET)):
+                return
+            glWidget = glWidgetRef()
+            if not glWidget:
+                return
+            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tf:
+                params[GLFILENAME] = tf.name
+                if pngExp := glWidget.exportToPNG(tf.name, params):
+                    pngExp.writePNGFile()
+                    pngExp.clear()
+                pix = QtGui.QPixmap(tf.name)
+            self.previewLabel.setPixmap(pix.scaled(self.previewLabel.size(), QtCore.Qt.KeepAspectRatio,
+                                                   QtCore.Qt.SmoothTransformation))
+            Path(tf.name).unlink(missing_ok=True)
+        except Exception:
+            pass
+
+    @queueStateChange(_verifyPopupApply)
     def _queueStripPaddingCallback(self, _value):
         textFromValue = self.stripPaddingBox.textFromValue
         oldValue = textFromValue(self.printSettings.stripPadding or 0.0)
         if _value >= 0 and textFromValue(_value) != oldValue:
+            self._schedulePreview()
             return partial(self._setStripPadding, _value)
 
     def _setStripPadding(self, value):


### PR DESCRIPTION
## Summary
- add new `GLTICKDENSITY` option for axis tick spacing
- support tick density in OpenGL widgets and exporters
- provide preview image in ExportStripToFile dialog
- include tick density parameter and default setting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840552209d083218d2adc1430a10034